### PR TITLE
Set content-type for html/css/js

### DIFF
--- a/gitea.go
+++ b/gitea.go
@@ -102,14 +102,14 @@ func (m Middleware) ServeHTTP(w http.ResponseWriter, r *http.Request, _ caddyhtt
 		return caddyhttp.Error(http.StatusNotFound, err)
 	}
 
-	SetMimeType(w, r.URL.Path)
+	SetContentType(w, r.URL.Path)
 	_, err = io.Copy(w, f)
 
 	return err
 }
 
 // Sets the Content-Type for js, css and html so browsers actually load the stuff
-func SetMimeType(w http.ResponseWriter, filePath string) {
+func SetContentType(w http.ResponseWriter, filePath string) {
 	if strings.HasSuffix(filePath, ".css") {
 		w.Header().Set("Content-Type", "text/css")
 	} else if strings.HasSuffix(filePath, ".js") {

--- a/gitea.go
+++ b/gitea.go
@@ -102,9 +102,21 @@ func (m Middleware) ServeHTTP(w http.ResponseWriter, r *http.Request, _ caddyhtt
 		return caddyhttp.Error(http.StatusNotFound, err)
 	}
 
+	SetMimeType(w, r.URL.Path)
 	_, err = io.Copy(w, f)
 
 	return err
+}
+
+// Sets the Content-Type for js, css and html so browsers actually load the stuff
+func SetMimeType(w http.ResponseWriter, filePath string) {
+	if strings.HasSuffix(filePath, ".css") {
+		w.Header().Set("Content-Type", "text/css")
+	} else if strings.HasSuffix(filePath, ".js") {
+		w.Header().Set("Content-Type", "application/javascript")
+	} else if strings.HasSuffix(filePath, ".html") {
+		w.Header().Set("Content-Type", "text/html")
+	}
 }
 
 // Interface guards


### PR DESCRIPTION
For my generated docs I noticed the CSS not loading. All files were being sent as `Content-Type: text/plain`

By setting the Content-Type to text/css, the styles get loaded as expected.

I just added something quick that checks the file ending and adds the matching Content-Type. Tested it on my own instance and it now loads my stuff as expected.