### PR TITLE
Add option to set defaultRef

### DIFF
--- a/pkg/gitea/gitea.go
+++ b/pkg/gitea/gitea.go
@@ -94,6 +94,11 @@ func (c *Client) Open(name, ref string) (fs.File, error) {
 		hasConfig = false
 	}
 
+	// Overwrite default ref if specified
+	if ref == "" && repo != c.giteapages && hasConfig {
+		ref = getDefaultPagesRef()
+	}
+
 	// if we don't have a config and the repo is the gitea-pages
 	// always overwrite the ref to the gitea-pages branch
 	if !hasConfig && (repo == c.giteapages || ref == c.giteapages) {
@@ -269,4 +274,11 @@ func validRefs(ref string, allowall bool) bool {
 	}
 
 	return false
+}
+
+func getDefaultPagesRef() string {
+	if !viper.IsSet("defaultRef") {
+		return ""
+	}
+	return viper.GetString("defaultRef")
 }


### PR DESCRIPTION
Mostly a convenience setting and to get closer to how github-pages work/are used.
When  you have a repo with default branch `main` for code and a `gitea-pages` branch for docs, you'd have to specify the ref for all links to the site.

So my proposal is a setting in the .toml to specify the default branch used for gitea-pages.

What do you think?